### PR TITLE
Working preview URL for articles in LC

### DIFF
--- a/sfdoc/publish/salesforce.py
+++ b/sfdoc/publish/salesforce.py
@@ -162,8 +162,8 @@ class Salesforce:
     def get_preview_url(self, ka_id, online=False):
         """Article preview URL."""
         preview_url = (
-            '{}/knowledge/publishing/'
-            'articlePreview.apexp?id={}'
+            '{}/apex/'
+            'Hub_KB_ProductDocArticle?id={}&preview=true&channel=APP'
         ).format(
             self.get_base_url(),
             ka_id[:15],  # reduce to 15 char ID


### PR DESCRIPTION
After enabling the Lightning Template, article preview URLs no longer work for users without Community Management permissions. As we cannot grant this permission to most sfdoc users, this instead directly references a visualforce endpoint.