### PR TITLE
Decode webhooks to Unicode instead of saving them as binary.

### DIFF
--- a/sfdoc/publish/views.py
+++ b/sfdoc/publish/views.py
@@ -170,6 +170,6 @@ def review(request, pk):
 @require_POST
 def webhook(request):
     """Receive webhook from easyDITA."""
-    webhook = Webhook.objects.create(body=request.body)
+    webhook = Webhook.objects.create(body=request.body.decode('utf-8'))
     process_webhook.delay(webhook.pk)
     return HttpResponse('OK')


### PR DESCRIPTION
"The function that processes the webhook is so small and simple? What could go wrong?"

Unicode could go wrong. Always Unicode.

