### PR TITLE
Fix article preview URLs to properly load draft

### DIFF
--- a/sfdoc/publish/salesforce.py
+++ b/sfdoc/publish/salesforce.py
@@ -163,7 +163,7 @@ class Salesforce:
         """Article preview URL."""
         preview_url = (
             '{}{}'
-            '?id={}&preview=true&channel=APP'
+            '?id={}&preview=true&pubstatus=d&channel=APP'
         ).format(
             self.get_base_url(),
             settings.SALESFORCE_ARTICLE_PREVIEW_URL_PATH_PREFIX,

--- a/sfdoc/publish/tests/test_salesforce.py
+++ b/sfdoc/publish/tests/test_salesforce.py
@@ -85,7 +85,7 @@ class TestSalesforce(TestCase):
         ka_url = salesforce.get_preview_url('123')
         self.assertEqual(
             ka_url,
-            'https://sb-{}.cs70.force.com{}?id=123&preview=true&channel=APP'.format(
+            'https://sb-{}.cs70.force.com{}?id=123&preview=true&pubstatus=d&channel=APP'.format(
                 settings.SALESFORCE_COMMUNITY,
                 settings.SALESFORCE_ARTICLE_PREVIEW_URL_PATH_PREFIX
             ),


### PR DESCRIPTION
This fixes a problem where the generated draft preview URLs no longer work after the article is published.