### PR TITLE
Replace code for unchanged images.

### DIFF
--- a/sfdoc/publish/amazon.py
+++ b/sfdoc/publish/amazon.py
@@ -13,6 +13,7 @@ from . import utils
 
 logger = getLogger("awss3")
 
+
 class S3:
 
     def __init__(self, bundle):
@@ -117,7 +118,7 @@ class S3:
             if filecmp.cmp(filename, s3localname):
                 # files are the same, no update
                 logger.info("Images are the same: %s, %s", filename, s3localname)
-
+                self.upload_image(filename, draft_key)
                 return
             else:
                 # files differ, update image

--- a/sfdoc/publish/tasks.py
+++ b/sfdoc/publish/tasks.py
@@ -177,24 +177,6 @@ def create_drafts(bundle, html_files, path, salesforce_docset, s3):
             image.replace(path + os.sep, ''),
         )
         s3.process_image(image, path)
-    # upload unchanged images for article previews
-    logger.info('Checking for unchanged images used in draft articles')
-    unchanged_images = set([])
-    for image_set in article_image_map.values():
-        for image in image_set:
-            relpath = utils.bundle_relative_path(path, image)
-            logger.info("Collected %s", relpath)
-            if not bundle.images.filter(filename=relpath):
-                unchanged_images.add(image)
-    for n, image in enumerate(unchanged_images, start=1):
-        logger.info('Uploading unchanged image %d of %d: %s',
-            n,
-            len(unchanged_images),
-            image
-        )
-        relative_filename = utils.bundle_relative_path(path, image)
-        key = Image.get_storage_path(bundle.docset_id, relative_filename, draft=True)
-        s3.upload_image(image, key)
     # error if nothing changed
     if not bundle.articles.count() and not bundle.images.count():
         raise SfdocError('No articles or images changed')


### PR DESCRIPTION
Why have a special algorithm for finding and uploading unchanged images when we can upload them as soon as we detect them?

Is there a subtlety I'm missing?

Unit and Integration tests pass.

There IS a subtlety about evaluating this code. It would be natural to say: "if the image didn't change, why are we uploading it?"

The answer is that the differencing is against Public/Online/Prod, not against "Draft". We have *no idea* what state the draft images folder is in. So we must upload all images to draft.

The previous programmer recognized that (I guess) and wrote an algorithm for uploading them. But I don't understand why we need an algorithm. Just upload them in the same function that you'd upload them if they had changed or were new.

This function could probably be streamlined but there are inline returns so I'd rather be safe than sorry and rewrite it some other year.