### PR TITLE
Attach loggers to specific object, not just class.

### DIFF
--- a/sfdoc/publish/logger.py
+++ b/sfdoc/publish/logger.py
@@ -24,7 +24,7 @@ class LogStream(object):
 
 def get_logger(model):
     """Get an instance of the logger."""
-    logger_name = 'sfdoc_{}'.format(model.__class__.__name__)
+    logger_name = f'sfdoc_{model.__class__.__name__}{model.pk}'
     logger = logging.getLogger(logger_name)
     if logger.handlers:
         # already configured


### PR DESCRIPTION
Loggers were looked up by classname but had streams attached to specific instances. In some weird circumstances they could send the wrong log message to the wrong instance. I don't know of any negative side effects of being more specific in our log naming.
