### PR TITLE
Time-sensitive: Allow re-publishing identical bundles.

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -310,3 +310,7 @@ SALESFORCE_DOCSET_RELATION_FIELD = SALESFORCE_DOCSET_SOBJECT
 
 # this will slow things down and should only be used for testing
 CACHE_VALIDATION_MODE = env("CACHE_VALIDATION_MODE", default=False)
+
+# sometimes you need to re-publish unchanged articles because the 
+# publishing process itself has changed (e.g. new SF-side metadata)
+REPUBLISH_UNCHANGED_ARTICLES = env("REPUBLISH_UNCHANGED_ARTICLES", default=False)

--- a/sfdoc/publish/salesforce.py
+++ b/sfdoc/publish/salesforce.py
@@ -278,7 +278,7 @@ class SalesforceArticles:
             # new draft of existing article
             record = result_online[0]
             # check for changes in article fields
-            if html.same_as_record(record):
+            if html.same_as_record(record) and not settings.REPUBLISH_UNCHANGED_ARTICLES:
                 # no update
                 logger.info("Draft did not change: skipping: %s", html.url_name)
                 return

--- a/sfdoc/publish/tests/test_integration.py
+++ b/sfdoc/publish/tests/test_integration.py
@@ -10,6 +10,7 @@ from . import utils
 
 import boto3
 from django.conf import settings
+from django.test import override_settings
 from django.db import connection
 from test_plus.test import TestCase
 import responses
@@ -665,7 +666,7 @@ class SFDocTestIntegration(TestCase, TstHelpers):
             self.assertEqual(self.salesforce.get_articles("draft"), [])
 
     def test_same_bundle_push_and_publish_twice(self):
-        """Currently you can't pubish identical bundles back to back."""
+        """You can't publish identical bundles back to back usually."""
         bundle_A = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
         tasks.publish_drafts(bundle_A.pk)  # simulate publish from UI
         try:
@@ -674,6 +675,14 @@ class SFDocTestIntegration(TestCase, TstHelpers):
             assert str(e) == 'No articles or images changed'
         else:
             tasks.publish_drafts(bundle_A2.pk)  # simulate publish from UI
+
+    @override_settings(REPUBLISH_UNCHANGED_ARTICLES='True')
+    def test_same_bundle_force_republish(self):
+        """Allow publishing identical bundle twice in a row if settings allow."""
+        bundle_A = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
+        tasks.publish_drafts(bundle_A.pk)  # simulate publish from UI
+        bundle_A2 = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
+        tasks.publish_drafts(bundle_A2.pk)  # simulate publish from UI
 
     def test_same_bundle_old_bundle(self):
         """Should be able to revert a publish"""

--- a/sfdoc/publish/tests/test_integration.py
+++ b/sfdoc/publish/tests/test_integration.py
@@ -665,22 +665,23 @@ class SFDocTestIntegration(TestCase, TstHelpers):
             # no articles should still be in draft
             self.assertEqual(self.salesforce.get_articles("draft"), [])
 
+    @override_settings(REPUBLISH_UNCHANGED_ARTICLES=False)
     def test_same_bundle_push_and_publish_twice(self):
         """You can't publish identical bundles back to back usually."""
         bundle_A = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
         tasks.publish_drafts(bundle_A.pk)  # simulate publish from UI
-        try:
-            bundle_A2 = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
-        except SfdocError as e:  # this is okay
-            assert str(e) == 'No articles or images changed'
-        else:
-            tasks.publish_drafts(bundle_A2.pk)  # simulate publish from UI
+        with self.assertRaises(SfdocError) as e:
+            self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
+        
+        assert str(e.exception) == 'No articles or images changed'
 
-    @override_settings(REPUBLISH_UNCHANGED_ARTICLES='True')
+    @override_settings(REPUBLISH_UNCHANGED_ARTICLES=True)
     def test_same_bundle_force_republish(self):
         """Allow publishing identical bundle twice in a row if settings allow."""
         bundle_A = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
         tasks.publish_drafts(bundle_A.pk)  # simulate publish from UI
+        # if the setting did not do what it is supposed to do, the next line
+        # would throw an exception, as it does in test_same_bundle_push_and_publish_twice
         bundle_A2 = self.process_bundle_from_webhook(fake_easydita.fake_webhook_body_doc_A)
         tasks.publish_drafts(bundle_A2.pk)  # simulate publish from UI
 

--- a/sfdoc/publish/tests/utils.py
+++ b/sfdoc/publish/tests/utils.py
@@ -198,7 +198,8 @@ def mock_easydita():
     for filename in glob.glob(os.path.join(rootdir, "testdata/bundles/*.zip")):
         UUID = os.path.splitext(os.path.basename(filename))[0]
         url = f"https://salesforce.easydita.com/rest/all-files/{UUID}/bundle"
-        responses.add(responses.GET, url, body=open(filename, "rb"))
+        with open(filename, "rb") as f:
+            responses.add(responses.GET, url, body=f.read())
 
     responses.add_passthru("https://test.salesforce.com")
 


### PR DESCRIPTION
Allow SFDoc to work in a mode where it is will re-publish articles that haven't changed.

This allows us to force refreshes of metadata, which we will need to do Wednesday.
