### PR TITLE
Add logging and testing for the compare-articles feature

### DIFF
--- a/sfdoc/publish/salesforce.py
+++ b/sfdoc/publish/salesforce.py
@@ -278,7 +278,7 @@ class SalesforceArticles:
             # new draft of existing article
             record = result_online[0]
             # check for changes in article fields
-            if html.same_as_record(record) and not settings.REPUBLISH_UNCHANGED_ARTICLES:
+            if html.same_as_record(record, logger) and not settings.REPUBLISH_UNCHANGED_ARTICLES:
                 # no update
                 logger.info("Draft did not change: skipping: %s", html.url_name)
                 return

--- a/sfdoc/publish/tests/test_html.py
+++ b/sfdoc/publish/tests/test_html.py
@@ -118,3 +118,22 @@ class TestHTML(TestCase):
         updated = HTML.update_links_production(html)
         assert "/draft/" not in updated
         assert "/public/" in updated
+
+    def test_compare(self):
+        logger = logging.getLogger("test")
+        record = utils.gen_article(1)
+        print(self.article)
+        html = self.html(self.html_s)
+        record = {"ArticleAuthor__c": html.author,
+                "ArticleAuthorOverride__c": html.author_override,
+                "IsVisibleInCsp": html.is_visible_in_csp,
+                "IsVisibleInPkb": html.is_visible_in_pkb,
+                "IsVisibleInPrm": html.is_visible_in_prm,
+                "Title": html.title,
+                "Summary": html.summary,
+                "ArticleBody__c": html.body,
+                }
+        assert html.same_as_record(record, logger)
+        record["Title"] = "Foo"
+        assert not html.same_as_record(record, logger)
+


### PR DESCRIPTION
The comparison feature isn't working reliably. I've added a bit of testing and logging for it to try and narrow it down.